### PR TITLE
Teams

### DIFF
--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
@@ -3,9 +3,12 @@ package com.woodongleee.src.teams_2;
 import com.woodongleee.config.BaseException;
 import com.woodongleee.config.BaseResponse;
 import com.woodongleee.src.teams_2.model.AddTeamScheduleReq;
+import com.woodongleee.src.teams_2.model.TeamApplyListRes;
 import com.woodongleee.utils.JwtService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/teams")
@@ -106,6 +109,18 @@ public class Teams_2Controller {
 
             String result = "가입 거절 성공";
             return new BaseResponse<>(result);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    @GetMapping("{teamIdx}/apply")
+    public BaseResponse<List<TeamApplyListRes>> getTeamApplyList(@PathVariable int teamIdx){
+        try{
+            int userIdx = jwtService.getUserIdx();
+            List<TeamApplyListRes> teamApplyListResList = teams2Provider.getTeamApplyList(userIdx, teamIdx);
+
+            return new BaseResponse<>(teamApplyListResList);
         } catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
@@ -67,4 +67,19 @@ public class Teams_2Controller {
             return new BaseResponse<>(e.getStatus());
         }
     }
+
+
+    // 팀원 추방
+    @PatchMapping("/users/{userIdx}/drop")
+    public BaseResponse<String> dropUser(@PathVariable int userIdx){
+        try{
+            int leaderIdx = jwtService.getUserIdx();
+            teams2Service.dropUser(leaderIdx, userIdx);
+
+            String result = "팀원 추방 성공";
+            return new BaseResponse<>(result);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
@@ -97,4 +97,18 @@ public class Teams_2Controller {
         }
     }
 
+    // 팀 가입 요청 거절
+    @PatchMapping("/apply/{teamApplyIdx}/reject")
+    public BaseResponse<String> rejectUser(@PathVariable int teamApplyIdx){
+        try{
+            int userIdx = jwtService.getUserIdx();
+            teams2Service.rejectUser(teamApplyIdx, userIdx);
+
+            String result = "가입 거절 성공";
+            return new BaseResponse<>(result);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
@@ -82,4 +82,19 @@ public class Teams_2Controller {
             return new BaseResponse<>(e.getStatus());
         }
     }
+
+    // 팀 가입 요청 승인
+    @PatchMapping("/apply/{teamApplyIdx}/accept")
+    public BaseResponse<String> acceptUser(@PathVariable int teamApplyIdx){
+        try{
+            int userIdx = jwtService.getUserIdx();
+            teams2Service.acceptUser(teamApplyIdx, userIdx);
+
+            String result = "가입 승인 성공";
+            return new BaseResponse<>(result);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
@@ -54,4 +54,17 @@ public class Teams_2Controller {
             return new BaseResponse<>(e.getStatus());
         }
     }
+
+    // 팀 해체
+    @PatchMapping("{teamIdx}/status")
+    public BaseResponse<String> disbandTeam(@PathVariable int teamIdx){
+        try {
+            int userIdx = jwtService.getUserIdx();
+            teams2Service.disbandTeam(userIdx, teamIdx);
+            String result = "팀 해체 성공";
+            return new BaseResponse<>(result);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Controller.java
@@ -2,6 +2,7 @@ package com.woodongleee.src.teams_2;
 
 import com.woodongleee.config.BaseException;
 import com.woodongleee.config.BaseResponse;
+import com.woodongleee.src.teams_2.model.AddTeamScheduleReq;
 import com.woodongleee.utils.JwtService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -40,4 +41,17 @@ public class Teams_2Controller {
         }
     }
 
+    // 팀 일정 추가
+    @PostMapping("{teamIdx}/schedule")
+    public BaseResponse<String> addTeamSchedule(@RequestBody AddTeamScheduleReq addTeamScheduleReq, @PathVariable int teamIdx){
+        try{
+            int userIdx = jwtService.getUserIdx();
+            teams2Service.addTeamSchedule(addTeamScheduleReq, teamIdx, userIdx);
+
+            String result = "팀원 일정 추가 완료";
+            return new BaseResponse<>(result);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
@@ -107,4 +107,14 @@ public class Teams_2Dao {
         String Query3 = "update User set teamIdx=? where userIdx=?;"; // 유저 정보 갱신
         this.jdbcTemplate.update(Query3, Params);
     }
+
+    public void rejectUser(int teamApplyIdx) {
+        String Query = "update TeamApply set status='DENIED' where teamApplyIdx=?;";
+        this.jdbcTemplate.update(Query, teamApplyIdx);
+    }
+
+    public String getTeamApplyStatus(int teamApplyIdx) {
+        String Query = "select status from TeamApply where teamApplyIdx=?;";
+        return this.jdbcTemplate.queryForObject(Query, String.class, teamApplyIdx);
+    }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
@@ -67,6 +67,7 @@ public class Teams_2Dao {
     }
 
     public void disbandTeam(int teamIdx) {
+        Object[] Params = new Object[] {teamIdx, teamIdx};
 
         // {팀 일정, 유저 일정, 팀의 포스트, 포스트에 대한 신청} 삭제
         this.jdbcTemplate.execute("SET foreign_key_checks  = 0;");
@@ -75,7 +76,7 @@ public class Teams_2Dao {
                 "left join UserSchedule US on TS.teamScheduleIdx = US.teamScheduleIdx\n" +
                 "left join MatchPost MP on TS.teamScheduleIdx = MP.teamScheduleIdx\n" +
                 "left join MatchApply MA on MP.matchPostIdx = MA.matchPostIdx\n" +
-                "where homeIdx=?;", teamIdx);
+                "where homeIdx=? or awayIdx=?;", Params);
         this.jdbcTemplate.execute("SET foreign_key_checks  = 1;");
 
         // 유저 정보와 팀 신청 내역 업데이트

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
@@ -2,11 +2,13 @@ package com.woodongleee.src.teams_2;
 
 import com.woodongleee.src.teams_2.model.AcceptUserRes;
 import com.woodongleee.src.teams_2.model.AddTeamScheduleReq;
+import com.woodongleee.src.teams_2.model.TeamApplyListRes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.util.List;
 
 @Repository
 public class Teams_2Dao {
@@ -116,5 +118,14 @@ public class Teams_2Dao {
     public String getTeamApplyStatus(int teamApplyIdx) {
         String Query = "select status from TeamApply where teamApplyIdx=?;";
         return this.jdbcTemplate.queryForObject(Query, String.class, teamApplyIdx);
+    }
+
+    public List<TeamApplyListRes> getTeamApplyList(int teamIdx) {
+        String Query = "select teamApplyIdx, userIdx, status from TeamApply where teamIdx=?;";
+        return this.jdbcTemplate.query(Query, (rs, rowNum) ->
+                new TeamApplyListRes(
+                        rs.getInt("teamApplyIdx"),
+                        rs.getInt("userIdx"),
+                        rs.getString("status")), teamIdx);
     }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
@@ -1,5 +1,6 @@
 package com.woodongleee.src.teams_2;
 
+import com.woodongleee.src.teams_2.model.AcceptUserRes;
 import com.woodongleee.src.teams_2.model.AddTeamScheduleReq;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -91,5 +92,19 @@ public class Teams_2Dao {
         String Query = "update User set teamIdx=null where userIdx=?";
         this.jdbcTemplate.update(Query, userIdx);
 
+    }
+
+    public void acceptUser(int teamApplyIdx) {
+        String Query1 = "update TeamApply set status='ACCEPTED' where teamApplyIdx=?;"; // 팀 신청 수락
+        String Query2 = "select userIdx, teamIdx from TeamApply where teamApplyIdx=?;"; // TeamApply 테이블에서 유저, 팀 정보 가져오기
+        this.jdbcTemplate.update(Query1, teamApplyIdx);
+        AcceptUserRes acceptUserRes = this.jdbcTemplate.queryForObject(Query2, ((rs, rowNum) -> new AcceptUserRes(
+                rs.getInt("userIdx"),
+                rs.getInt("teamIdx")
+        )), teamApplyIdx);
+
+        Object[] Params = new Object[]{acceptUserRes.getTeamIdx(), acceptUserRes.getUserIdx()};
+        String Query3 = "update User set teamIdx=? where userIdx=?;"; // 유저 정보 갱신
+        this.jdbcTemplate.update(Query3, Params);
     }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
@@ -75,11 +75,21 @@ public class Teams_2Dao {
                 "where homeIdx=?;", teamIdx);
         this.jdbcTemplate.execute("SET foreign_key_checks  = 1;");
 
-
-
         // 유저 정보와 팀 신청 내역 업데이트
         this.jdbcTemplate.update("update User set teamIdx=null, isLeader='F' where teamIdx=?;", teamIdx);
         this.jdbcTemplate.update("update TeamApply set status='DENIED' where teamIdx=?;", teamIdx);
         this.jdbcTemplate.update("update TeamInfo set status='INACTIVE' where teamIdx=?;", teamIdx);
+    }
+
+    public int getTeamIdx(int userIdx) {
+        String Query = "select teamIdx from User where userIdx=?;";
+        return this.jdbcTemplate.queryForObject(Query, int.class, userIdx);
+    }
+
+    public void dropUser(int userIdx) {
+        // 탈퇴 이전에 참여한 팀 경기에 대해서는 계속 참여 상태로 유지됩니다.
+        String Query = "update User set teamIdx=null where userIdx=?";
+        this.jdbcTemplate.update(Query, userIdx);
+
     }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Dao.java
@@ -1,5 +1,6 @@
 package com.woodongleee.src.teams_2;
 
+import com.woodongleee.src.teams_2.model.AddTeamScheduleReq;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -45,5 +46,20 @@ public class Teams_2Dao {
         String Query2 = "select if((select isRecruiting from TeamInfo where teamIdx=?)='TRUE', 1, -1)";
 
         return this.jdbcTemplate.queryForObject(Query2, int.class, teamIdx);
+    }
+
+    public void addTeamSchedule(AddTeamScheduleReq addTeamScheduleReq, int teamIdx) {
+        String Query = "insert into TeamSchedule(homeIdx, address, startTime, endTime, date, headCnt) values(?,?,?,?,?,?);";
+        Object[] Params = new Object[] {teamIdx, addTeamScheduleReq.getAddress(), addTeamScheduleReq.getStartTime(),
+                addTeamScheduleReq.getEndTime(), addTeamScheduleReq.getDate(), addTeamScheduleReq.getHeadCnt()};
+
+        this.jdbcTemplate.update(Query, Params);
+    }
+
+    public int checkTimeOfSchedule(String startTime, String endTime) {
+        String Query = "select exists(select * from TeamSchedule where startTime >=? and endTime <=?);";
+        Object[] Params = new Object[] {startTime, endTime};
+
+        return this.jdbcTemplate.queryForObject(Query, int.class, Params);
     }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Provider.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Provider.java
@@ -1,20 +1,58 @@
 package com.woodongleee.src.teams_2;
 
+import com.woodongleee.config.BaseException;
+import com.woodongleee.config.BaseResponseStatus;
+import com.woodongleee.src.teams_2.model.TeamApplyListRes;
+import com.woodongleee.src.user.UserProvider;
 import com.woodongleee.utils.JwtService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.woodongleee.config.BaseResponseStatus.*;
 
 @Service
 public class Teams_2Provider {
     private final Teams_2Dao teams2Dao;
     private final JwtService jwtService;
 
+    private final UserProvider userProvider;
+
     @Autowired
-    public Teams_2Provider(Teams_2Dao teams2Dao, JwtService jwtService){
+    public Teams_2Provider(Teams_2Dao teams2Dao, JwtService jwtService, UserProvider userProvider){
         this.teams2Dao = teams2Dao;
-        this.jwtService=jwtService;
+        this.jwtService = jwtService;
+        this.userProvider = userProvider;
     }
 
 
+    public List<TeamApplyListRes> getTeamApplyList(int userIdx, int teamIdx) throws BaseException {
+        try{
+            if(userProvider.checkUserExist(userIdx) == 0){
+                throw new BaseException(USER_DOES_NOT_EXIST);
+            }
+            if(userProvider.checkUserStatus(userIdx).equals("INACTIVE")){
+                throw new BaseException(LEAVED_USER);
+            }
+            if(teams2Dao.isLeader(userIdx) != 1){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // 리더가 아닌 경우
+            }
 
+            if(teams2Dao.checkTeamIdxExist(teamIdx) != 1){
+                throw new BaseException(TEAM_DOES_NOT_EXIST); // 팀이 존재하지 않음(해체된 경우도 포함)
+            }
+
+            if(teams2Dao.isOurTeam(userIdx, teamIdx) != 1){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // teamIdx와 userIdx가 매치되지 않는 경우
+            }
+
+            return teams2Dao.getTeamApplyList(teamIdx);
+
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
@@ -170,6 +170,11 @@ public class Teams_2Service {
                 throw new BaseException(ACCEPT_NOT_AVAILABLE); // 리더가 아닌 경우
             }
 
+            String status = teams2Dao.getTeamApplyStatus(teamApplyIdx);
+            if(!status.equals("APPLIED")){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // 신청이 취소되었거나 이미 거절된 경우
+            }
+
             teams2Dao.acceptUser(teamApplyIdx);
         } catch (BaseException e) {
             throw e;
@@ -189,7 +194,7 @@ public class Teams_2Service {
             if(teams2Dao.isLeader(userIdx) != 1){
                 throw new BaseException(ACCEPT_NOT_AVAILABLE); // 리더가 아닌 경우
             }
-            
+
             String status = teams2Dao.getTeamApplyStatus(teamApplyIdx);
             if(!status.equals("APPLIED")){
                 throw new BaseException(ACCEPT_NOT_AVAILABLE); // 신청이 취소되었거나 이미 거절된 경우

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
@@ -2,6 +2,7 @@ package com.woodongleee.src.teams_2;
 
 import com.woodongleee.config.BaseException;
 import com.woodongleee.config.BaseResponseStatus;
+import com.woodongleee.src.teams_2.model.AddTeamScheduleReq;
 import com.woodongleee.src.user.UserProvider;
 import com.woodongleee.utils.JwtService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +49,39 @@ public class Teams_2Service {
                 throw new BaseException(ACCEPT_NOT_AVAILABLE); // teamIdx와 userIdx가 매치되지 않는 경우
             }
             return teams2Dao.changeTeamRecruit(teamIdx);
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
+        }
+    }
+
+    public void addTeamSchedule(AddTeamScheduleReq addTeamScheduleReq, int teamIdx, int userIdx) throws BaseException{
+        try{
+            if(userProvider.checkUserExist(userIdx) == 0){
+                throw new BaseException(USER_DOES_NOT_EXIST);
+            }
+            if(userProvider.checkUserStatus(userIdx).equals("INACTIVE")){
+                throw new BaseException(LEAVED_USER);
+            }
+
+            if(teams2Dao.isLeader(userIdx) != 1){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // 리더가 아닌 경우
+            }
+
+            if(teams2Dao.checkTeamIdxExist(teamIdx) != 1){
+                throw new BaseException(TEAM_DOES_NOT_EXIST); // 팀이 존재하지 않음
+            }
+
+            if(teams2Dao.isOurTeam(userIdx, teamIdx) != 1){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // teamIdx와 userIdx가 매치되지 않는 경우
+            }
+
+            if(teams2Dao.checkTimeOfSchedule(addTeamScheduleReq.getStartTime(), addTeamScheduleReq.getEndTime()) == 1){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // 시간이 안 맞는 경우
+            }
+
+            teams2Dao.addTeamSchedule(addTeamScheduleReq, teamIdx);
         } catch (BaseException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
@@ -106,7 +106,7 @@ public class Teams_2Service {
             }
 
             if(teams2Dao.isOurTeam(userIdx, teamIdx) != 1){
-                throw new BaseException(LEAVED_USER); // teamIdx와 userIdx가 매치되지 않는 경우
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // teamIdx와 userIdx가 매치되지 않는 경우
             }
 
             teams2Dao.disbandTeam(teamIdx);

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
@@ -119,4 +119,42 @@ public class Teams_2Service {
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
     }
+
+    public void dropUser(int leaderIdx, int userIdx) throws BaseException{
+        try{
+            if(userProvider.checkUserExist(userIdx) == 0){
+                throw new BaseException(USER_DOES_NOT_EXIST);
+            }
+            if(userProvider.checkUserStatus(userIdx).equals("INACTIVE")){
+                throw new BaseException(LEAVED_USER);
+            }
+            if(userProvider.checkUserExist(leaderIdx) == 0){
+                throw new BaseException(USER_DOES_NOT_EXIST);
+            }
+            if(userProvider.checkUserStatus(leaderIdx).equals("INACTIVE")){
+                throw new BaseException(LEAVED_USER);
+            }
+            // 유저 탈퇴 여부 확인
+
+            if(teams2Dao.isLeader(leaderIdx) != 1){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // 리더가 아닌 경우
+            }
+
+            int teamIdx = teams2Dao.getTeamIdx(leaderIdx); // 리더의 팀idx
+
+            if(teams2Dao.checkTeamIdxExist(teamIdx) != 1){
+                throw new BaseException(TEAM_DOES_NOT_EXIST); // 팀이 존재하지 않음(해체된 경우도 포함)
+            }
+
+            if(teams2Dao.isOurTeam(userIdx, teamIdx) != 1){
+                throw new BaseException(LEAVED_USER); // teamIdx와 userIdx가 매치되지 않는 경우
+            }
+
+            teams2Dao.dropUser(userIdx);
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
@@ -177,4 +177,29 @@ public class Teams_2Service {
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
     }
+
+    public void rejectUser(int teamApplyIdx, int userIdx) throws BaseException{
+        try{
+            if(userProvider.checkUserExist(userIdx) == 0){
+                throw new BaseException(USER_DOES_NOT_EXIST);
+            }
+            if(userProvider.checkUserStatus(userIdx).equals("INACTIVE")){
+                throw new BaseException(LEAVED_USER);
+            }
+            if(teams2Dao.isLeader(userIdx) != 1){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // 리더가 아닌 경우
+            }
+            
+            String status = teams2Dao.getTeamApplyStatus(teamApplyIdx);
+            if(!status.equals("APPLIED")){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // 신청이 취소되었거나 이미 거절된 경우
+            }
+
+            teams2Dao.rejectUser(teamApplyIdx);
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
@@ -88,4 +88,35 @@ public class Teams_2Service {
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
     }
+
+    public void disbandTeam(int userIdx, int teamIdx) throws BaseException{
+        try{
+            if(userProvider.checkUserExist(userIdx) == 0){
+                throw new BaseException(USER_DOES_NOT_EXIST);
+            }
+            if(userProvider.checkUserStatus(userIdx).equals("INACTIVE")){
+                throw new BaseException(LEAVED_USER);
+            }
+            if(teams2Dao.isLeader(userIdx) != 1){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // 리더가 아닌 경우
+            }
+
+            if(teams2Dao.checkTeamIdxExist(teamIdx) != 1){
+                throw new BaseException(TEAM_DOES_NOT_EXIST); // 팀이 존재하지 않음(해체된 경우도 포함)
+            }
+
+            if(teams2Dao.isOurTeam(userIdx, teamIdx) != 1){
+                throw new BaseException(LEAVED_USER); // teamIdx와 userIdx가 매치되지 않는 경우
+            }
+
+            teams2Dao.disbandTeam(teamIdx);
+
+
+
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
+++ b/src/main/java/com/woodongleee/src/teams_2/Teams_2Service.java
@@ -157,4 +157,24 @@ public class Teams_2Service {
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
     }
+
+    public void acceptUser(int teamApplyIdx, int userIdx) throws BaseException{
+        try{
+            if(userProvider.checkUserExist(userIdx) == 0){
+                throw new BaseException(USER_DOES_NOT_EXIST);
+            }
+            if(userProvider.checkUserStatus(userIdx).equals("INACTIVE")){
+                throw new BaseException(LEAVED_USER);
+            }
+            if(teams2Dao.isLeader(userIdx) != 1){
+                throw new BaseException(ACCEPT_NOT_AVAILABLE); // 리더가 아닌 경우
+            }
+
+            teams2Dao.acceptUser(teamApplyIdx);
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/woodongleee/src/teams_2/model/AcceptUserRes.java
+++ b/src/main/java/com/woodongleee/src/teams_2/model/AcceptUserRes.java
@@ -1,0 +1,13 @@
+package com.woodongleee.src.teams_2.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class AcceptUserRes {
+    private int userIdx;
+    private int teamIdx;
+}

--- a/src/main/java/com/woodongleee/src/teams_2/model/AddTeamScheduleReq.java
+++ b/src/main/java/com/woodongleee/src/teams_2/model/AddTeamScheduleReq.java
@@ -1,0 +1,17 @@
+package com.woodongleee.src.teams_2.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class AddTeamScheduleReq {
+    private String address;
+    private String startTime;
+    private String endTime;
+    private String date;
+    private int headCnt;
+}

--- a/src/main/java/com/woodongleee/src/teams_2/model/TeamApplyListRes.java
+++ b/src/main/java/com/woodongleee/src/teams_2/model/TeamApplyListRes.java
@@ -1,0 +1,14 @@
+package com.woodongleee.src.teams_2.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class TeamApplyListRes {
+    private int teamApplyIdx;
+    private int userIdx;
+    private String status;
+}


### PR DESCRIPTION
- 팀 일정 추가
- 팀 해체
- 팀원 추방
- 팀 가입 신청 승인
- 팀 가입 신청 거절
- 팀 가입 요청 목록 조회

팀원 추방의 경우, 추방과 동시에 참가 투표를 했던 팀의 경기에 대해서 참가 취소되도록 구현하는 것을 생각 했으나
일정을 삭제한다면 경기 시작까지 2시간이 남지 않은 경우가 애매해져서
추방 되기 전 참가 투표를 한 경기에 대해서 참가 상태를 유지하는 방식으로 구현했습니다.
다른 의견 남겨주시면, 참고해서 수정하겠습니다.

(에러 코드들은 한 번에 취합해서 수정하고 pr 올리겠습니다.)
